### PR TITLE
Fix parent relationships on initial load

### DIFF
--- a/src/arena.js
+++ b/src/arena.js
@@ -270,9 +270,11 @@ export class Arena {
             ARENA.loadSceneObjects();
         });
 
-        // after scene is completely loaded, add user camera
-        ARENA.events.on(ARENAEventEmitter.events.SCENE_OBJ_LOADED, () => {
-            ARENA.loadUser();
+        // after scene is completely loaded, add user camera if this is the initial scene load
+        ARENA.events.on(ARENAEventEmitter.events.SCENE_OBJ_LOADED, (initialLoad) => {
+            if (initialLoad) {
+                ARENA.loadUser();
+            }
         });
     };
 

--- a/src/arena.js
+++ b/src/arena.js
@@ -418,7 +418,7 @@ export class Arena {
                     const parentId = obj.attributes.parent;
                     if (parentId) {
                         // Stash parentID map
-                        orphanObjects.set(parentId, obj);
+                        orphanObjects.set(obj.object_id, parentId);
                         // Temporarily place it at scene or container root
                         delete obj.attributes.parent;
                     }
@@ -436,16 +436,18 @@ export class Arena {
                 }
             }
             // Go through orphans and attach them to their parents
-            for (const [parentId, obj] of orphanObjects) {
+            for (const [objId, parentId] of orphanObjects) {
+                const obj = document.getElementById(objId);
                 const parent = document.getElementById(parentId);
-                if (parent) {
+                if (parent && obj) {
                     try { // Handles DOMExceptions for circular references
                         parent.appendChild(obj);
                     } catch (e) {
-                        console.log('Error attaching orphan object', obj.object_id, e);
+                        console.log('Error attaching orphan object', objId, e);
                     }
+                } else {
+                    console.log('Missing object in relationship for', objId, parentId);
                 }
-                console.log('No parent for orphan object', obj.object_id);
             }
             window.setTimeout(
                 () => ARENA.events.emit(ARENAEventEmitter.events.SCENE_OBJ_LOADED, !(parentName || prefixName)),

--- a/src/arena.js
+++ b/src/arena.js
@@ -441,6 +441,7 @@ export class Arena {
                 const parent = document.getElementById(parentId);
                 if (parent && obj) {
                     try { // Handles DOMExceptions for circular references
+                        obj.parentElement.removeChild(obj);
                         parent.appendChild(obj);
                     } catch (e) {
                         console.log('Error attaching orphan object', objId, e);


### PR DESCRIPTION
Resolves #476 

Updated functionality: LoadSceneObjects can be called with a parentName 
and (subsequently required) prefixName to allow for loading of an "instance"
of another scene's objects onto a specified parent. First creates a container 
node given prefix (e.g. sceneB_container) so that sets of sceneObjects can
be easily moved or deleted in entirety.