### PR TITLE
Add camFollow to subscribe to position updates

### DIFF
--- a/src/arena.js
+++ b/src/arena.js
@@ -65,9 +65,6 @@ export class Arena {
         this.confstats = url.searchParams.get('confstats');
         this.hudstats = url.searchParams.get('hudstats');
         this.camFollow = url.searchParams.get('camFollow');
-        if (this.camFollow) {
-            document.getElementById('my-camera').removeAttribute('look-controls');
-        }
 
         // setup required scene-options defaults
         // TODO: pull these from a schema

--- a/src/arena.js
+++ b/src/arena.js
@@ -64,6 +64,7 @@ export class Arena {
         this.noname = url.searchParams.get('noname');
         this.confstats = url.searchParams.get('confstats');
         this.hudstats = url.searchParams.get('hudstats');
+        this.camFollow = url.searchParams.get('camFollow');
 
         // setup required scene-options defaults
         // TODO: pull these from a schema

--- a/src/arena.js
+++ b/src/arena.js
@@ -65,6 +65,9 @@ export class Arena {
         this.confstats = url.searchParams.get('confstats');
         this.hudstats = url.searchParams.get('hudstats');
         this.camFollow = url.searchParams.get('camFollow');
+        if (this.camFollow) {
+            document.getElementById('my-camera').removeAttribute('look-controls');
+        }
 
         // setup required scene-options defaults
         // TODO: pull these from a schema

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -107,7 +107,16 @@ export class CreateUpdate {
             if (message.ttl !== undefined) { // Allow falsy value of 0
                 entityEl.setAttribute('ttl', {seconds: message.ttl});
             }
-
+            if (id === ARENA.camFollow) {
+                this.handleCameraOverride(ACTIONS.UPDATE, {
+                    id: ARENA.camName,
+                    data: {
+                        object_type: 'camera',
+                        position: message.data.position,
+                        rotation: message.data.rotation,
+                    },
+                });
+            }
             return;
 
         case 'camera-override':

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -441,7 +441,7 @@ export class CreateUpdate {
             }
             const p = message.data.position;
             const r = message.data.rotation;
-            if (AFRAME.scenes[0].xrSession) { // Apply transform to rig based off xrSession camera pose
+            if (AFRAME.scenes[0]?.xrSession) { // Apply transform to rig based off xrSession camera pose
                 overrideMatrix.identity();
                 const rig = document.getElementById('cameraRig');
                 const spinner = document.getElementById('cameraSpinner');

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -464,18 +464,26 @@ export class CreateUpdate {
                 rig.object3D.position.setFromMatrixPosition(rigMatrix);
                 spinner.object3D.rotation.setFromRotationMatrix(rigMatrix);
             } else { // Do direct camera control. If there was a rig offset already ... maybe we should reset it?
-                if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
-                if (r) {
-                    if (r.hasOwnProperty('w')) {
-                        overrideQuat.set(r.x, r.y, r.z, r.w);
-                        overrideEuler.setFromQuaternion(overrideQuat);
-                        myCamera.components['look-controls'].yawObject.rotation.y = overrideEuler.y;
-                        myCamera.components['look-controls'].pitchObject.rotation.x = overrideEuler.x;
-                    } else {
-                        myCamera.components['look-controls'].yawObject.rotation.y = THREE.MathUtils.degToRad(r.y);
-                        myCamera.components['look-controls'].pitchObject.rotation.x = THREE.MathUtils.degToRad(r.x);
+                if (ARENA.camFollow) {
+                    const target = document.getElementById(ARENA.camFollow).object3D;
+                    if (target) {
+                        myCamera.object3D.matrix.copy(target.matrix);
                     }
-                    Logger.warning('camera override', message);
+                } else {
+                    if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
+                    if (r) {
+                        if (r.hasOwnProperty('w')) {
+                            overrideQuat.set(r.x, r.y, r.z, r.w);
+                            overrideEuler.setFromQuaternion(overrideQuat);
+                            myCamera.components['look-controls'].yawObject.rotation.y = overrideEuler.y;
+                            myCamera.components['look-controls'].pitchObject.rotation.x = overrideEuler.x;
+                        } else {
+                            myCamera.components['look-controls'].yawObject.rotation.y = THREE.MathUtils.degToRad(
+                                r.y);
+                            myCamera.components['look-controls'].pitchObject.rotation.x = THREE.MathUtils.degToRad(
+                                r.x);
+                        }
+                    }
                 }
             }
         } else if (message.data.object_type === 'look-at') { // camera look-at

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -467,7 +467,8 @@ export class CreateUpdate {
                 if (ARENA.camFollow) {
                     const target = document.getElementById(ARENA.camFollow).object3D;
                     if (target) {
-                        myCamera.object3D.matrix.copy(target.matrix);
+                        myCamera.object3D.position.copy(target.position);
+                        myCamera.object3D.rotation.copy(target.rotation);
                     }
                 } else {
                     if (p) myCamera.object3D.position.set(p.x, p.y, p.z);

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -11,7 +11,8 @@ const ACTIONS = {
 const RENDER_ORDER = 1;
 
 const overrideMatrix = new THREE.Matrix4();
-const overrideMatrixInverse = new THREE.Matrix4();
+const camMatrixInverse = new THREE.Matrix4();
+const rigMatrix = new THREE.Matrix4();
 const overrideQuat = new THREE.Quaternion();
 const overrideEuler = new THREE.Euler();
 
@@ -458,9 +459,10 @@ export class CreateUpdate {
                         ));
                     }
                 }
-                overrideMatrixInverse.copy(myCamera.object3D.matrix).invert().multiply(overrideMatrix);
-                rig.object3D.position.setFromMatrixPosition(overrideMatrixInverse);
-                spinner.object3D.rotation.setFromRotationMatrix(overrideMatrixInverse);
+                camMatrixInverse.copy(myCamera.object3D.matrix).invert(); // camera matrix inverse
+                rigMatrix.multiplyMatrices(overrideMatrix, camMatrixInverse); // rig matrix = override * camera inverse
+                rig.object3D.position.setFromMatrixPosition(rigMatrix);
+                spinner.object3D.rotation.setFromRotationMatrix(rigMatrix);
             } else { // Do direct camera control. If there was a rig offset already ... maybe we should reset it?
                 if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
                 if (r) {

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -465,14 +465,13 @@ export class CreateUpdate {
                 if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
                 if (r) {
                     if (r.hasOwnProperty('w')) {
-                        myCamera.components['look-controls'].yawObject.rotation.setFromQuaternion(
-                            overrideQuat.set(r.x, r.y, r.z, r.w));
+                        overrideQuat.set(r.x, r.y, r.z, r.w);
+                        overrideEuler.setFromQuaternion(overrideQuat);
+                        myCamera.components['look-controls'].yawObject.rotation.y = overrideEuler.y;
+                        myCamera.components['look-controls'].pitchObject.rotation.x = overrideEuler.x;
                     } else {
-                        myCamera.components['look-controls'].yawObject.rotation.set(
-                            THREE.MathUtils.degToRad(r.x),
-                            THREE.MathUtils.degToRad(r.y),
-                            THREE.MathUtils.degToRad(r.z),
-                        );
+                        myCamera.components['look-controls'].yawObject.rotation.y = THREE.MathUtils.degToRad(r.y);
+                        myCamera.components['look-controls'].pitchObject.rotation.x = THREE.MathUtils.degToRad(r.x);
                     }
                     Logger.warning('camera override', message);
                 }

--- a/src/message-actions/create-update.js
+++ b/src/message-actions/create-update.js
@@ -452,26 +452,18 @@ export class CreateUpdate {
                     spinner.object3D.rotation.setFromRotationMatrix(rigMatrix);
                 }
             } else { // Do direct camera control. If there was a rig offset already ... maybe we should reset it?
-                if (ARENA.camFollow) {
-                    const target = document.getElementById(ARENA.camFollow);
-                    if (target) {
-                        myCamera.object3D.position.copy(target.object3D.position);
-                        myCamera.object3D.rotation.copy(target.object3D.rotation);
-                    }
-                } else {
-                    if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
-                    if (r) {
-                        if (r.hasOwnProperty('w')) {
-                            overrideQuat.set(r.x, r.y, r.z, r.w);
-                            overrideEuler.setFromQuaternion(overrideQuat);
-                            myCamera.components['look-controls'].yawObject.rotation.y = overrideEuler.y;
-                            myCamera.components['look-controls'].pitchObject.rotation.x = overrideEuler.x;
-                        } else {
-                            myCamera.components['look-controls'].yawObject.rotation.y = THREE.MathUtils.degToRad(
-                                r.y);
-                            myCamera.components['look-controls'].pitchObject.rotation.x = THREE.MathUtils.degToRad(
-                                r.x);
-                        }
+                if (p) myCamera.object3D.position.set(p.x, p.y, p.z);
+                if (r) {
+                    if (r.hasOwnProperty('w')) {
+                        overrideQuat.set(r.x, r.y, r.z, r.w);
+                        overrideEuler.setFromQuaternion(overrideQuat);
+                        myCamera.components['look-controls'].yawObject.rotation.y = overrideEuler.y;
+                        myCamera.components['look-controls'].pitchObject.rotation.x = overrideEuler.x;
+                    } else {
+                        myCamera.components['look-controls'].yawObject.rotation.y = THREE.MathUtils.degToRad(
+                            r.y);
+                        myCamera.components['look-controls'].pitchObject.rotation.x = THREE.MathUtils.degToRad(
+                            r.x);
                     }
                 }
             }

--- a/src/systems/armarker/armarker.js
+++ b/src/systems/armarker/armarker.js
@@ -128,8 +128,10 @@ AFRAME.registerSystem('armarker', {
             }
         }
 
-        // init cv pipeline
-        this.initCVPipeline();
+        // init cv pipeline, if we are not using an external localizer
+        if (!ARENA.camFollow) {
+            this.initCVPipeline();
+        }
     },
     /**
     * Setup cv pipeline (camera capture and cv worker)

--- a/src/systems/armarker/armarker.js
+++ b/src/systems/armarker/armarker.js
@@ -71,6 +71,8 @@ AFRAME.registerSystem('armarker', {
     * @alias module:armarker-system
     */
     init: function() {
+        const sceneEl = this.el;
+
         // init this.ATLASMarkers with list of markers within range
         this.getARMArkersFromATLAS(true);
 
@@ -84,17 +86,17 @@ AFRAME.registerSystem('armarker', {
             });
         }
 
-        // request camera acess features
-        const sceneEl = this.el;
-        const optionalFeatures = sceneEl.systems.webxr.data.optionalFeatures;
-        if (this.isWebARViewer) {
-            // eslint-disable-next-line max-len
-            optionalFeatures.push('computerVision'); // request custom 'computerVision' feature in WebXRViewer/WebARViewer
-        } else optionalFeatures.push('camera-access'); // request WebXR 'camera-access' otherwise
-        sceneEl.systems.webxr.sceneEl.setAttribute(
-            'optionalFeatures',
-            optionalFeatures,
-        );
+        // request camera access features
+        if (!ARENA.camFollow) {
+            const optionalFeatures = sceneEl.systems.webxr.data.optionalFeatures;
+            if (this.isWebARViewer) {
+                optionalFeatures.push('computerVision'); // request custom 'computerVision' feature in XRBrowser
+            } else optionalFeatures.push('camera-access'); // request WebXR 'camera-access' otherwise
+            sceneEl.systems.webxr.sceneEl.setAttribute(
+                'optionalFeatures',
+                optionalFeatures,
+            );
+        }
 
         // listner for xr session start
         if (sceneEl.hasWebXR && navigator.xr && navigator.xr.addEventListener) {

--- a/src/webar/index.js
+++ b/src/webar/index.js
@@ -45,7 +45,10 @@ export class ARENAWebARUtils {
      */
     static handleARButtonForNonWebXRMobile() {
         if (ARENA.camFollow) {
-            document.getElementById('my-camera').removeAttribute('look-controls');
+            const camera = document.getElementById('my-camera');
+            camera.setAttribute('look-controls', 'touchEnabled', false);
+            camera.setAttribute('look-controls', 'mouseEnabled', false);
+            camera.setAttribute('wasd-controls', 'enabled', false);
         }
 
         if (this.isWebARViewer) {

--- a/src/webar/index.js
+++ b/src/webar/index.js
@@ -22,7 +22,7 @@ export class ARENAWebARUtils {
         // }
 
         // hack: only allow smartphones and tablets?
-        if (!('ontouchstart' in window)) {
+        if (!('ontouchstart' in window) && !ARENA.camFollow ) {
             return;
         }
 
@@ -34,12 +34,16 @@ export class ARENAWebARUtils {
      * Adds the AR button for non-WebXR devices
      */
     static handleARButtonForNonWebXRMobile() {
+        if (ARENA.camFollow) {
+            document.getElementById('my-camera').removeAttribute('look-controls');
+        }
+
         if (this.isWebARViewer) {
             return;
         }
 
         // hack: only allow smartphones and tablets?
-        if (!('ontouchstart' in window)) {
+        if (!('ontouchstart' in window) && !ARENA.camFollow) {
             return;
         }
 

--- a/src/webar/index.js
+++ b/src/webar/index.js
@@ -6,6 +6,7 @@
  * @date 2020
  */
 import './ar-session.js';
+import {WebARCameraCapture} from '../systems/armarker/camera-capture/ccwebar';
 
 const HIDDEN_CLASS = 'a-hidden';
 
@@ -28,6 +29,15 @@ export class ARENAWebARUtils {
 
         const sceneEl = document.querySelector('a-scene');
         sceneEl.setAttribute('arena-webar-session', '');
+
+        if (ARENA.camFollow) {
+            try {
+                this.cameraCapture = new WebARCameraCapture();
+                this.cameraCapture.initCamera();
+            } catch (err) {
+                console.error(`No valid CV camera capture found. ${err}`);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Used typically when an external localizer pushes updates for a tracked object, and
a client can subscribe to that object (e.g. `box1`) rather than the localizer having to
know the clients' `object_id`s itself.

Works in both Desktop, AR, and virtual-AR (via webcam background passthrough).

Disables AprilTag CV