### PR TITLE
Single pubsub

### DIFF
--- a/src/components/arena-user.js
+++ b/src/components/arena-user.js
@@ -46,7 +46,9 @@ AFRAME.registerComponent('arena-user', {
 
         this.arena = sceneEl.systems['arena-scene'];
         this.jitsi = sceneEl.systems['arena-jitsi'];
+        this.chat = sceneEl.systems["arena-chat-ui"];
 
+        this.idTag = el.id.replace("camera_", "");
         el.setAttribute('rotation.order', 'YXZ');
         el.object3D.position.set(0, ARENADefaults.camHeight, 0);
         el.object3D.rotation.set(0, 0, 0);
@@ -451,10 +453,13 @@ AFRAME.registerComponent('arena-user', {
 
     remove: function () {
         // camera special case, look for hands to delete
-        const elHandL = document.getElementById(`handLeft_${ARENA.idTag}`);
+        const elHandL = document.getElementById(`handLeft_${this.idTag}`);
         if (elHandL) elHandL.remove();
-        const elHandR = document.getElementById(`handRight_${ARENA.idTag}`);
+        const elHandR = document.getElementById(`handRight_${this.idTag}`);
         if (elHandR) elHandR.remove();
+        // try to remove chat user
+        delete this.chat?.liveUsers[this.idTag];
+        this.chat?.populateUserList();
     },
 
     tick: function() {

--- a/src/core/mqtt.js
+++ b/src/core/mqtt.js
@@ -47,12 +47,16 @@ AFRAME.registerSystem('arena-mqtt', {
         const camName = this.arena.camName;
         const outputTopic = this.arena.outputTopic;
         // Do not pass functions in mqttClientOptions
-        await this.connect(
+        this.connect(
             {
                 reconnect: true,
                 userName: this.userName,
                 password: mqttToken,
             },
+            proxy(() => {
+                console.info("ARENA MQTT scene connection success!");
+                ARENA.events.emit(ARENA_EVENTS.MQTT_LOADED, true);
+            }),
             // last will message
             JSON.stringify({ object_id: camName, action: "delete" }),
             // last will topic
@@ -60,8 +64,6 @@ AFRAME.registerSystem('arena-mqtt', {
         );
 
         ARENA.Mqtt = this; // Restore old alias
-
-        ARENA.events.emit(ARENA_EVENTS.MQTT_LOADED, true);
     },
 
     initWorker: async function() {
@@ -93,11 +95,12 @@ AFRAME.registerSystem('arena-mqtt', {
 
     /**
      * @param {object} mqttClientOptions
-     * @param {string} lwMsg
-     * @param {string} lwTopic
+     * @param {function} [onSuccessCallBack]
+     * @param {string} [lwMsg]
+     * @param {string} [lwTopic]
      */
-    connect: async function(mqttClientOptions, lwMsg = undefined, lwTopic = undefined) {
-        await this.MQTTWorker.connect(mqttClientOptions, lwMsg, lwTopic);
+    connect(mqttClientOptions, onSuccessCallBack = undefined, lwMsg = undefined, lwTopic = undefined) {
+        this.MQTTWorker.connect(mqttClientOptions, onSuccessCallBack, lwMsg, lwTopic);
     },
 
     /**

--- a/src/core/workers/mqtt-worker.js
+++ b/src/core/workers/mqtt-worker.js
@@ -49,22 +49,27 @@ class MQTTWorker {
     /**
      * Connect mqtt client; If given, setup a last will message given as argument
      * @param {object} mqttClientOptions paho mqtt options
-     * @param {string} lwMsg last will message
-     * @param {string} lwTopic last will destination topic message
+     * @param {function} onSuccessCallBack callback function on successful connection
+     * @param {string} [lwMsg] last will message
+     * @param {string} [lwTopic] last will destination topic message
      */
-    async connect(mqttClientOptions, lwMsg=undefined, lwTopic=undefined) {
+    connect(mqttClientOptions, onSuccessCallBack, lwMsg = undefined, lwTopic = undefined) {
         const opts = {
-            ...mqttClientOptions,
-            onSuccess: function() {
-                console.info('ARENA MQTT scene connection success!');
-            },
             onFailure: function(res) {
                 this.healthCheck({
                     addError: 'mqttScene.connection',
                 });
                 console.error(`ARENA MQTT scene connection failed, ${res.errorCode}, ${res.errorMessage}`);
             },
+            ...mqttClientOptions,
         };
+        if (onSuccessCallBack) {
+            opts.onSuccess = onSuccessCallBack;
+        } else {
+            opts.onSuccess = () => {
+                console.info("ARENA MQTT scene connection success!");
+            };
+        }
 
         if (lwMsg && lwTopic && !mqttClientOptions.willMessage) {
             // Last Will and Testament message sent to subscribers if this client loses connection

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -655,11 +655,11 @@ AFRAME.registerSystem('arena-chat-ui', {
         // const willMessage = new Paho.Message(JSON.stringify(msg));
         // willMessage.destinationName = this.publishPublicTopic;
 
-        await this.mqttc.registerMessageHandler("c", proxy(this.onMessageArrived.bind(_this)), true);
-        await this.mqttc.addConnectionLostHandler(proxy(this.onConnectionLost.bind(_this)));
+        this.mqttc.registerMessageHandler("c", proxy(this.onMessageArrived.bind(_this)), true);
+        this.mqttc.addConnectionLostHandler(proxy(this.onConnectionLost.bind(_this)));
 
-        await this.mqttc.subscribe(this.subscribePublicTopic);
-        await this.mqttc.subscribe(this.subscribePrivateTopic);
+        this.mqttc.subscribe(this.subscribePublicTopic);
+        this.mqttc.subscribe(this.subscribePrivateTopic);
 
         this.keepalive();
         // periodically send a keep alive

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -642,19 +642,6 @@ AFRAME.registerSystem('arena-chat-ui', {
 
         const _this = this; /* save reference to class instance */
 
-        // TODO: figure out how to handle only 1 will message
-        // const msg = {
-        //     object_id: ARENAUtils.uuidv4(),
-        //     type: "chat-ctrl",
-        //     to_uid: "all",
-        //     from_uid: this.userId,
-        //     from_un: this.userName,
-        //     from_scene: this.scene,
-        //     text: "left",
-        // };
-        // const willMessage = new Paho.Message(JSON.stringify(msg));
-        // willMessage.destinationName = this.publishPublicTopic;
-
         this.mqttc.registerMessageHandler("c", proxy(this.onMessageArrived.bind(_this)), true);
         this.mqttc.addConnectionLostHandler(proxy(this.onConnectionLost.bind(_this)));
 
@@ -754,17 +741,16 @@ AFRAME.registerSystem('arena-chat-ui', {
             else this.populateUserList();
             this.keepalive(); // let this user know about us
         } else if (msg.from_un !== undefined && msg.from_scene !== undefined) {
+            if (msg?.text === "left") {
+                delete this.liveUsers[msg.from_uid];
+                this.populateUserList();
+                return;
+            }
             this.liveUsers[msg.from_uid].un = msg.from_un;
             this.liveUsers[msg.from_uid].scene = msg.from_scene;
             this.liveUsers[msg.from_uid].cid = msg.cameraid;
             this.liveUsers[msg.from_uid].ts = new Date().getTime();
             this.liveUsers[msg.from_uid].type = UserType.ARENA;
-            if (msg.text) {
-                if (msg.text == 'left') {
-                    delete this.liveUsers[msg.from_uid];
-                    this.populateUserList();
-                }
-            }
         }
 
         // process commands

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -35,6 +35,8 @@ AFRAME.registerSystem('arena-chat-ui', {
 
         if (!data.enabled) return;
 
+        this.sceneEl.addEventListener(JITSI_EVENTS.CONNECTED, this.onJitsiConnect.bind(this));
+
         ARENA.events.addMultiEventListener([
             ARENA_EVENTS.ARENA_LOADED,
             ARENA_EVENTS.MQTT_LOADED,
@@ -364,7 +366,6 @@ AFRAME.registerSystem('arena-chat-ui', {
         }
 
         this.onNewSettings = this.onNewSettings.bind(this);
-        this.onJitsiConnect = this.onJitsiConnect.bind(this);
         this.onUserJoin = this.onUserJoin.bind(this);
         this.onScreenshare = this.onScreenshare.bind(this);
         this.onUserLeft = this.onUserLeft.bind(this);
@@ -377,7 +378,6 @@ AFRAME.registerSystem('arena-chat-ui', {
         this.onJitsiStatus = this.onJitsiStatus.bind(this);
 
         sceneEl.addEventListener(ARENA_EVENTS.NEW_SETTINGS, this.onNewSettings);
-        sceneEl.addEventListener(JITSI_EVENTS.CONNECTED, this.onJitsiConnect);
         sceneEl.addEventListener(JITSI_EVENTS.USER_JOINED, this.onUserJoin);
         sceneEl.addEventListener(JITSI_EVENTS.SCREENSHARE, this.onScreenshare);
         sceneEl.addEventListener(JITSI_EVENTS.USER_LEFT, this.onUserLeft);
@@ -405,9 +405,6 @@ AFRAME.registerSystem('arena-chat-ui', {
      * @param {Object} e event object; e.detail contains the callback arguments
      */
     onJitsiConnect: function(e) {
-        const data = this.data;
-        const el = this.el;
-
         const args = e.detail;
         args.pl.forEach((user) => {
             // console.log('Jitsi User: ', user);
@@ -421,8 +418,6 @@ AFRAME.registerSystem('arena-chat-ui', {
                     ts: new Date().getTime(),
                     type: UserType.EXTERNAL, // indicate we only know about the user from jitsi
                 };
-                if (args.scene === this.scene) this.populateUserList(this.liveUsers[user.id]);
-                else this.populateUserList();
             }
         });
     },

--- a/src/ui/chat.js
+++ b/src/ui/chat.js
@@ -57,7 +57,7 @@ AFRAME.registerSystem('arena-chat-ui', {
         this.status = {};
 
         // users list
-        this.liveUsers = [];
+        this.liveUsers = {};
 
         this.userId = this.arena.idTag;
         this.cameraId = this.arena.camName;


### PR DESCRIPTION
Consolidate main scene and chat topics

- JSON serialization now occurs entirely on worker
- Allows for registering message handlers per topic category (`realm/<category>/...`), currently `s` and `c` address scene and chat categories
- Since only 1 connection exists, only 1 lastwill can be directed to a singular topic. As such, the user "left" mechanism is no longer a message but passed from the `arena-user` camera `remove()` lifecycle method.