### PR TITLE
Add blip in/out effect

### DIFF
--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -260,7 +260,7 @@
                 },
                 "planes": {
                     "default": "both",
-                    "description": "Which which planes (and direction) to animate out",
+                    "description": "Which which clipping planes to use for effect. A top plane clips above it, bottom clips below it",
                     "type": "string",
                     "enum": ["both", "top", "bottom"]
                 },

--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -247,6 +247,12 @@
                     "type": "boolean",
                     "description": "Animate out on delete, set false to disable"
                 },
+                "geometry": {
+                    "default": "rect",
+                    "description": "Geometry of the blipout plane",
+                    "type": "string",
+                    "enum": ["rect", "disk", "ring"]
+                },
                 "duration": {
                     "default": 750,
                     "type": "number",
@@ -254,6 +260,7 @@
                 }
             },
             "required": [
+                "geometry",
                 "duration"
             ]
         },

--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -268,6 +268,11 @@
                     "default": 750,
                     "type": "number",
                     "description": "Animation duration in milliseconds"
+                },
+                "applyDescendants": {
+                    "default": false,
+                    "type": "boolean",
+                    "description": "Apply blipout effect to include all descendents. Does not work for blipin"
                 }
             },
             "required": [

--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -237,6 +237,26 @@
             "title": "Collision Listener (legacy)",
             "type": "string"
         },
+        "blipout": {
+            "description": "When the object is deleted, it will animate out of the scene instead of disappearing instantly",
+            "title": "Blip Out on Delete",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "default": true,
+                    "type": "boolean",
+                    "description": "Animate out on delete, set false to disable"
+                },
+                "duration": {
+                    "default": 750,
+                    "type": "number",
+                    "description": "Animation duration in milliseconds"
+                }
+            },
+            "required": [
+                "duration"
+            ]
+        },
         "color": {
             "deprecated": true,
             "default": "#ffa500",

--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -237,12 +237,17 @@
             "title": "Collision Listener (legacy)",
             "type": "string"
         },
-        "blipout": {
-            "description": "When the object is deleted, it will animate out of the scene instead of disappearing instantly",
-            "title": "Blip Out on Delete",
+        "blip": {
+            "description": "When the object is created or deleted, it will animate in/out of the scene instead of appearing/disappearing instantly. Must have a geometric mesh.",
+            "title": "Blip Effect",
             "type": "object",
             "properties": {
-                "enabled": {
+                "blipin": {
+                    "default": true,
+                    "type": "boolean",
+                    "description": "Animate in on create, set false to disable"
+                },
+                "blipout": {
                     "default": true,
                     "type": "boolean",
                     "description": "Animate out on delete, set false to disable"
@@ -266,6 +271,9 @@
                 }
             },
             "required": [
+                "blipin",
+                "blipout",
+                "planes",
                 "geometry",
                 "duration"
             ]

--- a/build/schemas/definitions-common.json
+++ b/build/schemas/definitions-common.json
@@ -253,6 +253,12 @@
                     "type": "string",
                     "enum": ["rect", "disk", "ring"]
                 },
+                "planes": {
+                    "default": "both",
+                    "description": "Which which planes (and direction) to animate out",
+                    "type": "string",
+                    "enum": ["both", "top", "bottom"]
+                },
                 "duration": {
                     "default": 750,
                     "type": "number",

--- a/src/components/camera/arena-user.js
+++ b/src/components/camera/arena-user.js
@@ -125,6 +125,8 @@ AFRAME.registerComponent('arena-user', {
 
         const name = el.id;
 
+        el.setAttribute('blip', { blipin: false, geometry: 'disk', applyDescendants: true });
+
         const decodeName = decodeURI(name.split('_')[2]);
         const personName = decodeName.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
         this.headText = document.createElement('a-text');
@@ -140,6 +142,7 @@ AFRAME.registerComponent('arena-user', {
         this.headText.setAttribute('width', 5); // try setting last
 
         this.headModel = document.createElement('a-entity');
+        this.headModel.setAttribute('blip', { geometry: 'disk', blipout: false });
         this.headModel.setAttribute('id', `head-model-${name}`);
         this.headModel.setAttribute('rotation', '0 180 0');
         this.headModel.setAttribute('scale', '1 1 1');

--- a/src/components/camera/arena-user.js
+++ b/src/components/camera/arena-user.js
@@ -120,8 +120,6 @@ AFRAME.registerComponent('arena-user', {
 
         this.idTag = el.id.replace('camera_', '');
         el.setAttribute('rotation.order', 'YXZ');
-        el.object3D.position.set(0, ARENA.defaults.camHeight, 0);
-        el.object3D.rotation.set(0, 0, 0);
 
         const name = el.id;
 

--- a/src/components/object/blip.js
+++ b/src/components/object/blip.js
@@ -15,17 +15,24 @@ AFRAME.registerComponent('blip', {
             el: { object3D },
         } = this;
         if (data.blipin === true && object3D.children.length === 0) {
+            this.checkBlipIn = this.checkBlipIn.bind(this);
+            this.initCount = 0;
             object3D.visible = false;
             // On initial node creation, no geometry or material is loaded yet
-            el.addEventListener(
-                'object3dset',
-                () => {
-                    this.blip('in');
-                },
-                { once: true }
-            );
+            el.addEventListener('object3dset', this.checkBlipIn, { once: true });
+            // Object3D is set before geometry and material
+            el.addEventListener('loaded', this.checkBlipIn, { once: true });
         }
     },
+    checkBlipIn() {
+        this.initCount += 1;
+        if (this.initCount === 2) {
+            setTimeout(() => {
+                this.blip('in');
+            }, 50); // Need to release main thread for geometry to load properly
+        }
+    },
+
     blip(dir) {
         const {
             data,

--- a/src/components/object/blipout.js
+++ b/src/components/object/blipout.js
@@ -2,9 +2,10 @@
 
 AFRAME.registerComponent('blipout', {
     schema: {
+        enabled: { type: 'boolean', default: true },
         duration: { type: 'number', default: 750 },
     },
-    init() {
+    blip() {
         const {
             el,
             el: { object3D, sceneEl },

--- a/src/components/object/blipout.js
+++ b/src/components/object/blipout.js
@@ -1,0 +1,67 @@
+/* global AFRAME, THREE */
+
+import { SkinnedMesh } from 'three-shim';
+
+AFRAME.registerComponent('blipout', {
+    schema: {
+        duration: { type: 'number', default: 1000 },
+    },
+    init() {
+        const {
+            el,
+            el: { object3D, sceneEl },
+        } = this;
+        if (!el.getAttribute('geometry') && !el.getAttribute('gltf-model')) {
+            // Only blip geometry and gltfs
+            el.remove();
+            return;
+        }
+        sceneEl.renderer.localClippingEnabled = true;
+        sceneEl.renderer.clipShadows = true;
+        const meshTargets = [
+            ...object3D.getObjectsByProperty('isMesh', true),
+            ...object3D.getObjectsByProperty('isSkinnedMesh', true),
+        ];
+        const matTargets = meshTargets.filter((matTarget) => matTarget.material);
+        if (matTargets.length === 0) {
+            // No materials to clip (???), just remove it
+            el.remove();
+            return;
+        }
+
+        // Determine min and max heights of object
+        const bbox = new THREE.Box3();
+        bbox.setFromObject(object3D);
+        const minY = bbox.min.y;
+        const maxY = bbox.max.y;
+        const midY = (minY + maxY) / 2;
+
+        // Create clipping planes
+        const planeBot = new THREE.Plane(new THREE.Vector3(0, 1, 0), -minY); // Clips everything below
+        const planeTop = new THREE.Plane(new THREE.Vector3(0, -1, 0), maxY); // Clips everything above
+
+        // Set planes to clip each material
+        matTargets.forEach((matTarget) => {
+            /* eslint-disable no-param-reassign */
+            matTarget.material.clippingPlanes = [planeBot, planeTop];
+            matTarget.material.clipShadows = true;
+            /* eslint-disable no-param-reassign */
+        });
+
+        AFRAME.ANIME({
+            targets: planeBot,
+            constant: -midY,
+            easing: 'easeOutCubic',
+            duration: this.data.duration,
+        });
+        AFRAME.ANIME({
+            targets: planeTop,
+            constant: midY,
+            easing: 'easeOutCubic',
+            duration: this.data.duration + 1, // ensure later than bottom
+            complete: () => {
+                el.remove.bind(el)();
+            },
+        });
+    },
+});

--- a/src/components/object/blipout.js
+++ b/src/components/object/blipout.js
@@ -4,9 +4,11 @@ AFRAME.registerComponent('blipout', {
     schema: {
         enabled: { type: 'boolean', default: true },
         duration: { type: 'number', default: 750 },
+        geometry: { type: 'string', default: 'rect' }, // [rect, disk, ring]
     },
     blip() {
         const {
+            data,
             el,
             el: { object3D, sceneEl },
         } = this;
@@ -36,33 +38,51 @@ AFRAME.registerComponent('blipout', {
         const midY = (minY + maxY) / 2;
         const width = bbox.max.x - bbox.min.x;
         const depth = bbox.max.z - bbox.min.z;
+        const radius = Math.max(width, depth) / 2;
 
         // Create clipping planes
         const planeBot = new THREE.Plane(new THREE.Vector3(0, 1, 0), -minY); // Clips everything below
         const planeTop = new THREE.Plane(new THREE.Vector3(0, -1, 0), maxY); // Clips everything above
 
+        const planeMeshMaterial = new THREE.MeshPhongMaterial({
+            color: 0x049ef4,
+            emissive: 0x000080,
+            specular: 0xffffff,
+            transparent: true,
+            opacity: 0.75,
+            shininess: 100,
+            side: THREE.DoubleSide,
+        });
+
+        switch (data.geometry) {
+            case 'disk': {
+                // 2d disk
+                this.meshPlaneBot = new THREE.Mesh(new THREE.RingGeometry(0, radius), planeMeshMaterial);
+                break;
+            }
+            case 'ring': {
+                // 2d ring
+                this.meshPlaneBot = new THREE.Mesh(
+                    new THREE.RingGeometry(radius, Math.min(radius + 0.15, radius * 1.1)),
+                    planeMeshMaterial
+                );
+                break;
+            }
+            default: // 2d rect
+                this.meshPlaneBot = new THREE.Mesh(new THREE.PlaneGeometry(width, depth), planeMeshMaterial);
+        }
+
         // Add visible mesh planes to match clipping
-        const meshPlaneBot = new THREE.Mesh(
-            new THREE.PlaneGeometry(width, depth),
-            new THREE.MeshPhongMaterial({
-                color: 0x049ef4,
-                emissive: 0x000080,
-                specular: 0xffffff,
-                transparent: true,
-                opacity: 0.75,
-                shininess: 100,
-                side: THREE.DoubleSide,
-            })
-        );
-        bbox.getCenter(meshPlaneBot.position); // align in world pos
-        meshPlaneBot.rotation.x = -Math.PI / 2; // rotate flat
 
-        const meshPlaneTop = meshPlaneBot.clone(); // clone bottom
+        bbox.getCenter(this.meshPlaneBot.position); // align in world pos
+        this.meshPlaneBot.rotation.x = -Math.PI / 2; // rotate horizontal flat
 
-        meshPlaneBot.position.y = minY;
-        meshPlaneTop.position.y = maxY;
+        this.meshPlaneTop = this.meshPlaneBot.clone(); // clone bottom as top
 
-        sceneEl.object3D.add(meshPlaneBot, meshPlaneTop); // Add to sceneroot for world space
+        this.meshPlaneBot.position.y = minY; // Only variation is difference in y pos
+        this.meshPlaneTop.position.y = maxY;
+
+        sceneEl.object3D.add(this.meshPlaneBot, this.meshPlaneTop); // Add to sceneroot for world space
 
         matTargets.forEach((matTarget) => {
             /* eslint-disable no-param-reassign */
@@ -72,20 +92,20 @@ AFRAME.registerComponent('blipout', {
         });
 
         AFRAME.ANIME({
-            targets: [planeBot, meshPlaneBot.position], // constant, y ignored in vec3, plane respectively
+            targets: [planeBot, this.meshPlaneBot.position], // constant, y ignored in vec3, plane respectively
             constant: -midY,
             y: midY,
             easing: 'easeInOutSine',
-            duration: this.data.duration,
+            duration: data.duration,
         });
         AFRAME.ANIME({
-            targets: [planeTop, meshPlaneTop.position],
+            targets: [planeTop, this.meshPlaneTop.position],
             constant: midY,
             y: midY,
             easing: 'easeInOutSine',
-            duration: this.data.duration + 1, // ensure later than bottom
+            duration: data.duration + 1, // ensure later than bottom
             complete: () => {
-                sceneEl.object3D.remove(meshPlaneBot, meshPlaneTop);
+                sceneEl.object3D.remove(this.meshPlaneBot, this.meshPlaneTop);
                 el.remove.bind(el)();
             },
         });

--- a/src/components/object/index.js
+++ b/src/components/object/index.js
@@ -12,7 +12,7 @@
 
 import './armarker';
 import './attribution';
-import './blipout';
+import './blip';
 import './click-listener';
 import './collision-listener';
 import './gltf-lod';

--- a/src/components/object/index.js
+++ b/src/components/object/index.js
@@ -12,6 +12,7 @@
 
 import './armarker';
 import './attribution';
+import './blipout';
 import './click-listener';
 import './collision-listener';
 import './gltf-lod';

--- a/src/systems/core/message-actions/create-update.js
+++ b/src/systems/core/message-actions/create-update.js
@@ -235,6 +235,12 @@ export default class CreateUpdate {
             warn('Malformed message; type is undefined; attributes might not be set correctly.');
         }
 
+        if (message.action === ACTIONS.CREATE && data.blip?.blipin === true) {
+            // special case where we want to handle this attribute before any others like gltf or geometry
+            entityEl.setAttribute('blip', data.blip);
+            delete data.blip; // remove attribute so we don't reset it later
+        }
+
         // handle geometries and some type special cases
         // TODO: using components (e.g. for headtext, image, ...) that handle these would allow to remove most of the
         // special cases

--- a/src/systems/core/message-actions/delete.js
+++ b/src/systems/core/message-actions/delete.js
@@ -1,7 +1,5 @@
 /* global AFRAME */
 
-const info = AFRAME.utils.debug('ARENA:delete:info');
-const warn = AFRAME.utils.debug('ARENA:delete:warn');
 const error = AFRAME.utils.debug('ARENA:delete:error');
 
 /**
@@ -42,8 +40,8 @@ export default class Delete {
      * @param el - element to remove
      */
     static blipRemove(el) {
-        if (el.components.blipout?.data?.enabled) {
-            el.components.blipout.blip();
+        if (el.components.blip?.data?.blipout === true) {
+            el.components.blip.blip('out');
         } else {
             el.remove();
         }

--- a/src/systems/core/message-actions/delete.js
+++ b/src/systems/core/message-actions/delete.js
@@ -27,19 +27,25 @@ export default class Delete {
         // Clean up linked dependents
         try {
             document.querySelectorAll(`[dep=${id}]`).forEach((depEl) => {
-                const depParentEl = depEl.parentEl;
-                if (depParentEl) {
-                    depParentEl.removeChild(depEl);
-                }
+                this.blipRemove(depEl);
             });
         } catch (e) {
-            console.error( e );
+            console.error(e);
         }
 
         // Remove element itself
-        const { parentEl } = entityEl;
-        if (parentEl) {
-            parentEl.removeChild(entityEl);
+        this.blipRemove(entityEl);
+    }
+
+    /**
+     * Remove element with blip effect if it has the component and is set as enabled
+     * @param el - element to remove
+     */
+    static blipRemove(el) {
+        if (el.components.blipout?.data?.enabled) {
+            el.components.blipout.blip();
+        } else {
+            el.remove();
         }
     }
 }


### PR DESCRIPTION
Uses three.js clip plane to create effects

Applies to camera heads by default, can be removed if effect is disruptive