### PR TITLE
feat: Batch MQTT worker messages

### DIFF
--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -14,8 +14,6 @@ import { ARENA_EVENTS, ACTIONS } from '../../constants';
 const warn = AFRAME.utils.debug('ARENA:MQTT:warn');
 // const error = AFRAME.utils.debug('ARENA:MQTT:error');
 
-let lastMetricTick = new Date().getTime();
-
 AFRAME.registerSystem('arena-mqtt', {
     schema: {
         mqttHost: { type: 'string', default: ARENA.defaults.mqttHost },
@@ -149,11 +147,6 @@ AFRAME.registerSystem('arena-mqtt', {
      * @param {object} message
      */
     onSceneMessageArrived(message) {
-        const now = new Date().getTime();
-        if (now - lastMetricTick > 1000) {
-            console.log(`Worker message delay: ${now - message.workerTimestamp}ms`);
-            lastMetricTick = now;
-        }
         delete message.workerTimestamp;
         const theMessage = message.payloadObj; // This will be given as json
 

--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -84,7 +84,13 @@ AFRAME.registerSystem('arena-mqtt', {
             // }),
         );
         this.onSceneMessageArrived = this.onSceneMessageArrived.bind(this);
-        worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
+        worker.registerMessageHandler(
+            's',
+            proxy((messages) => {
+                messages.forEach(this.onSceneMessageArrived);
+            }),
+            true
+        );
         worker.registerMessageQueue('s', true);
         return worker;
     },

--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -84,7 +84,7 @@ AFRAME.registerSystem('arena-mqtt', {
             // }),
         );
         this.onSceneMessageArrived = this.onSceneMessageArrived.bind(this);
-        // worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
+        worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
         worker.registerMessageQueue('s', true);
         return worker;
     },

--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -85,7 +85,7 @@ AFRAME.registerSystem('arena-mqtt', {
         );
         this.onSceneMessageArrived = this.onSceneMessageArrived.bind(this);
         // worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
-        worker.registerMessageQueue('s');
+        worker.registerMessageQueue('s', true);
         return worker;
     },
 

--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -14,6 +14,8 @@ import { ARENA_EVENTS, ACTIONS } from '../../constants';
 const warn = AFRAME.utils.debug('ARENA:MQTT:warn');
 // const error = AFRAME.utils.debug('ARENA:MQTT:error');
 
+let lastMetricTick = new Date().getTime();
+
 AFRAME.registerSystem('arena-mqtt', {
     schema: {
         mqttHost: { type: 'string', default: ARENA.defaults.mqttHost },
@@ -139,6 +141,12 @@ AFRAME.registerSystem('arena-mqtt', {
      * @param {object} message
      */
     onSceneMessageArrived(message) {
+        const now = new Date().getTime();
+        if (now - lastMetricTick > 1000) {
+            console.log(`Worker message delay: ${now - message.workerTimestamp}ms`);
+            lastMetricTick = now;
+        }
+        delete message.workerTimestamp;
         const theMessage = message.payloadObj; // This will be given as json
 
         if (!theMessage) {

--- a/src/systems/core/mqtt.js
+++ b/src/systems/core/mqtt.js
@@ -83,7 +83,9 @@ AFRAME.registerSystem('arena-mqtt', {
             //     }
             // }),
         );
-        worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
+        this.onSceneMessageArrived = this.onSceneMessageArrived.bind(this);
+        // worker.registerMessageHandler('s', proxy(this.onSceneMessageArrived.bind(this)), true);
+        worker.registerMessageQueue('s');
         return worker;
     },
 
@@ -236,5 +238,11 @@ AFRAME.registerSystem('arena-mqtt', {
                 warn('Malformed message (invalid action field):', JSON.stringify(message));
                 break;
         }
+    },
+
+    tock() {
+        this.MQTTWorker?.tock('s').then((messages) => {
+            messages.forEach(this.onSceneMessageArrived);
+        });
     },
 });

--- a/src/systems/core/workers/mqtt-worker.js
+++ b/src/systems/core/workers/mqtt-worker.js
@@ -9,6 +9,8 @@
 import { expose } from 'comlink';
 import * as Paho from 'paho-mqtt'; // https://www.npmjs.com/package/paho-mqtt
 
+let lastMetricTick = new Date().getTime();
+
 /**
  * Main ARENA MQTT webworker client
  */
@@ -134,6 +136,11 @@ class MQTTWorker {
     tock(topicCategory) {
         const batch = this.messageQueues[topicCategory];
         this.messageQueues[topicCategory] = [];
+        const now = new Date().getTime();
+        if (now - lastMetricTick > 1000) {
+            console.log(`Worker batching ${batch.length} messages for ${topicCategory}`);
+            lastMetricTick = now;
+        }
         return batch;
     }
 

--- a/src/systems/core/workers/mqtt-worker.js
+++ b/src/systems/core/workers/mqtt-worker.js
@@ -118,6 +118,7 @@ class MQTTWorker {
         const topicCategory = topic.split('/')[1];
         const handler = this.messageHandlers[topicCategory];
         if (handler) {
+            message.workerTimestamp = new Date().getTime();
             handler(message);
         }
     }

--- a/src/systems/core/workers/mqtt-worker.js
+++ b/src/systems/core/workers/mqtt-worker.js
@@ -10,7 +10,6 @@ import { expose } from 'comlink';
 import * as Paho from 'paho-mqtt'; // https://www.npmjs.com/package/paho-mqtt
 
 const MINTOCKINTERVAL = 3 * 1000;
-let lastMetricTick = new Date().getTime();
 let lastTock = new Date().getTime();
 
 /**
@@ -158,10 +157,6 @@ class MQTTWorker {
         this.messageQueues[topicCategory] = [];
         const now = new Date().getTime();
         lastTock = now;
-        if (now - lastMetricTick > MINTOCKINTERVAL) {
-            console.log(`Worker batching ${batch.length} messages for ${topicCategory}`);
-            lastMetricTick = now;
-        }
         return batch;
     }
 

--- a/src/systems/core/workers/mqtt-worker.js
+++ b/src/systems/core/workers/mqtt-worker.js
@@ -9,7 +9,7 @@
 import { expose } from 'comlink';
 import * as Paho from 'paho-mqtt'; // https://www.npmjs.com/package/paho-mqtt
 
-const MINTOCKINTERVAL = 1000;
+const MINTOCKINTERVAL = 3 * 1000;
 let lastMetricTick = new Date().getTime();
 let lastTock = new Date().getTime();
 
@@ -146,7 +146,7 @@ class MQTTWorker {
                 this.messageQueues[topicCategory] = [];
                 lastTock = now;
                 console.log(`Worker flushing ${batch.length} messages for ${topicCategory}`);
-                batch.forEach(handler);
+                handler(batch);
             }
         } else if (handler) {
             handler(trimmedMessage);


### PR DESCRIPTION
Currently, all incoming messages received by the webworker are passed individually via comlink (postmessage) to the main thread. This can cause a backlog (probably) as a large number of message callbacks are handled by the main event loop. This problem is visible when a large number of updates/sec start to desync and show events at slower-than-realtime. When the program emitting these events on mqtt stops, the updates can be seen on the browser client slowly unwinding up to 10-15s later.

This change creates a buffer on the webworker side that is retrieved as a single batch of message every frame **tock**, then batch processed sequentially on the main thread (note that this does becomes blocking for extent of the entire batch). Since the buffer processing is dependent on frame rendering however, a drawback is that if a browser tab or window is minimized or backgrounded such that no frames are drawn, then the buffer will no longer be drained. As such, we include an interval threshhold (currently 3s) to force a batch process, so that when a user returns to the tab, the scene will be fairly up to date in state.

In informal tests, this significantly raises the ceiling for max updates/sec a client can handle. However it should be noted that greatly exceeding this limit per device no longer causes a framerate drop and slowdown of scene updates, but instead will drastically kill framerate and likely lead to entire client lockup.  This may actually be preferable so that a scene author knows something is immediately and obviously wrong with their scene update implementation.